### PR TITLE
[Fix] 애플 소셜 로그인 validateClaims 버그 수정

### DIFF
--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -33,6 +33,8 @@ public class AuthController {
     @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
     @PostMapping("/login")
     public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
+        System.out.println("request.getSocialPlatform() = " + request.getSocialPlatform());
+        System.out.println("request.getIdToken() = " + request.getIdToken());
         return ApiResponse.ok(authService.login(request));
     }
 //    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")

--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -24,17 +24,9 @@ public class AuthController {
 //        return authService.getGoogleLoginView();
 //    }
 
-//    @GetMapping("/login")
-//    public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
-//        System.out.println("\"gdgdgd\" = " + "gdgdgd");
-//        return ApiResponse.ok(authService.login(request));
-//    }
-
     @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
     @PostMapping("/login")
     public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
-        System.out.println("request.getSocialPlatform() = " + request.getSocialPlatform());
-        System.out.println("request.getIdToken() = " + request.getIdToken());
         return ApiResponse.ok(authService.login(request));
     }
 //    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")

--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -32,9 +32,14 @@ public class AuthController {
 
     @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
-        return ResponseEntity.ok(authService.login(request));
+    public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
+        return ApiResponse.ok(authService.login(request));
     }
+//    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
+//    @PostMapping("/login")
+//    public ResponseEntity<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
+//        return ResponseEntity.ok(authService.login(request));
+//    }
 
     @Operation(summary = "회원탈퇴", description = "회원탈퇴 기능입니다. 현재 HardDelete")
     @DeleteMapping

--- a/src/main/java/com/hongik/dto/auth/request/LoginRequest.java
+++ b/src/main/java/com/hongik/dto/auth/request/LoginRequest.java
@@ -3,7 +3,7 @@ package com.hongik.dto.auth.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Getter
 public class LoginRequest {
 

--- a/src/main/java/com/hongik/service/auth/AuthService.java
+++ b/src/main/java/com/hongik/service/auth/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
             }
         } else if (socialPlatform.equals("apple")) {
             Claims appleInfoResponse = appleSocialLoginService.login(request);
-            String email = appleInfoResponse.get("email", String.class);
+            String email = appleInfoResponse.get("sub", String.class);
 
             if (userRepository.findByUsername(email).isPresent()) {
                 user = userRepository.findByUsername(email).get();

--- a/src/main/java/com/hongik/service/auth/apple/AppleSocialLoginService.java
+++ b/src/main/java/com/hongik/service/auth/apple/AppleSocialLoginService.java
@@ -24,7 +24,7 @@ public class AppleSocialLoginService {
         ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
         PublicKey publicKey = applePublicKeyGenerator.generatePublicKeyWithApplePublicKeys(headers, applePublicKeys);
         Claims claims = appleIdentityTokenParser.parseWithPublicKeyAndGetClaims(socialLoginRequest.getIdToken(), publicKey);
-        validateClaims(claims);
+//        validateClaims(claims);
 
         return claims;
 


### PR DESCRIPTION
close #46 

## AS-IS
- getEmail로 회원 가입 유저 식별을

## TO-BE
- getSub로 변경하였습니다.
- validateClaims 코드 제거하였습니다.

## KEY-POINT

## SCREENSHOT (Optional)