### PR TITLE
[Feature] 유저 엔티티 sub컬럼을 추가하고 애플 로그인 sub 활용 기능 추가 구현

### DIFF
--- a/src/main/java/com/hongik/config/SecurityConfig.java
+++ b/src/main/java/com/hongik/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/week-field").hasRole("ADMIN")
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/env").permitAll()
-                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login", "/api/v1/auth/login-apple").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(new CustomJwtAuthenticationEntryPoint())

--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.hongik.controller.auth;
 
 import com.hongik.dto.ApiResponse;
+import com.hongik.dto.auth.request.AppleLoginRequest;
 import com.hongik.dto.auth.request.LoginRequest;
 import com.hongik.dto.auth.response.TokenResponse;
 import com.hongik.service.auth.AuthService;
@@ -24,7 +25,7 @@ public class AuthController {
 //        return authService.getGoogleLoginView();
 //    }
 
-    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
+    @Operation(summary = "구글 소셜 로그인", description = "구글, idToken을 넣어주세요.")
     @PostMapping("/login")
     public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
         return ApiResponse.ok(authService.login(request));
@@ -34,6 +35,12 @@ public class AuthController {
 //    public ResponseEntity<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
 //        return ResponseEntity.ok(authService.login(request));
 //    }
+
+    @Operation(summary = "애플 소셜 로그인", description = "애플, idToken, email을 넣어주세요.")
+    @PostMapping("/login-apple")
+    public ApiResponse<TokenResponse> selectAppleLoginInfo(@RequestBody AppleLoginRequest request){
+        return ApiResponse.ok(authService.appleLogin(request));
+    }
 
     @Operation(summary = "회원탈퇴", description = "회원탈퇴 기능입니다. 현재 HardDelete")
     @DeleteMapping

--- a/src/main/java/com/hongik/domain/user/User.java
+++ b/src/main/java/com/hongik/domain/user/User.java
@@ -32,21 +32,28 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private String sub;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<StudySession> studySessions = new ArrayList<>();
 
     @Builder
-    public User(final String username, final String password, final String nickname, final String department, final Role role) {
+    public User(final String username, final String password, final String nickname, final String department, final Role role, final String sub) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
         this.department = department;
         this.role = role;
+        this.sub = sub;
     }
 
     public void join(final String nickname, final String department) {
         this.nickname = nickname;
         this.department = department;
         this.role = Role.USER;
+    }
+
+    public void updateSub(final String sub) {
+        this.sub = sub;
     }
 }

--- a/src/main/java/com/hongik/dto/auth/request/AppleLoginRequest.java
+++ b/src/main/java/com/hongik/dto/auth/request/AppleLoginRequest.java
@@ -1,0 +1,23 @@
+package com.hongik.dto.auth.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AppleLoginRequest {
+
+    @Schema(example = "email@icloud.com")
+    private String email;
+
+    private String idToken;
+
+    @Builder
+    public AppleLoginRequest(final String email, final String idToken) {
+        this.email = email;
+        this.idToken = idToken;
+    }
+}

--- a/src/main/java/com/hongik/dto/auth/response/GoogleInfoResponse.java
+++ b/src/main/java/com/hongik/dto/auth/response/GoogleInfoResponse.java
@@ -9,22 +9,22 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GoogleInfoResponse {
 
-    private String id;
+    private String sub;
 
     private String name;
 
     private String email;
 
     @Builder
-    public GoogleInfoResponse(final String id, final String name, final String email) {
-        this.id = id;
+    public GoogleInfoResponse(final String sub, final String name, final String email) {
+        this.sub = sub;
         this.name = name;
         this.email = email;
     }
 
-    public static GoogleInfoResponse of(final String id, final String name, final String email) {
+    public static GoogleInfoResponse of(final String sub, final String name, final String email) {
         return GoogleInfoResponse.builder()
-                .id(id)
+                .sub(sub)
                 .name(name)
                 .email(email)
                 .build();

--- a/src/main/java/com/hongik/service/auth/apple/AppleSocialLoginService.java
+++ b/src/main/java/com/hongik/service/auth/apple/AppleSocialLoginService.java
@@ -1,5 +1,6 @@
 package com.hongik.service.auth.apple;
 
+import com.hongik.dto.auth.request.AppleLoginRequest;
 import com.hongik.dto.auth.request.LoginRequest;
 import com.hongik.exception.AppException;
 import com.hongik.exception.ErrorCode;
@@ -19,7 +20,7 @@ public class AppleSocialLoginService {
     private final ApplePublicKeyGenerator applePublicKeyGenerator;
     private final AppleIdentityTokenValidator appleIdentityTokenValidator;
 
-    public Claims login(LoginRequest socialLoginRequest) {
+    public Claims login(AppleLoginRequest socialLoginRequest) {
         Map<String, String> headers = appleIdentityTokenParser.parseHeaders(socialLoginRequest.getIdToken());
         ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
         PublicKey publicKey = applePublicKeyGenerator.generatePublicKeyWithApplePublicKeys(headers, applePublicKeys);


### PR DESCRIPTION
close #48 

## AS-IS
- 애플 로그인과 구글 로그인 api가 하나 였는데,

## TO-BE
- 애플과 구글 로그인을 분리
- sub 컬럼 추가

## KEY-POINT

## SCREENSHOT (Optional)