### PR TITLE
[Refactor] 닉네임 중복 검사 응답 형태 변경

### DIFF
--- a/src/main/java/com/hongik/controller/user/UserController.java
+++ b/src/main/java/com/hongik/controller/user/UserController.java
@@ -5,6 +5,7 @@ import com.hongik.dto.user.request.NicknameRequest;
 import com.hongik.dto.user.request.UserCreateRequest;
 import com.hongik.dto.user.request.UserJoinRequest;
 import com.hongik.dto.user.request.UsernameRequest;
+import com.hongik.dto.user.response.NicknameResponse;
 import com.hongik.dto.user.response.UserResponse;
 import com.hongik.service.user.UserService;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -35,8 +36,8 @@ public class UserController {
 
     @Operation(summary = "닉네임 중복검사", description = "닉네임 중복검사입니다.")
     @GetMapping("/duplicate-nickname")
-    public void duplicateNickname(@Valid @RequestBody NicknameRequest request) {
-        userService.checkNicknameDuplication(request.getNickname());
+    public ApiResponse<NicknameResponse> duplicateNickname(@Valid @RequestBody NicknameRequest request) {
+        return ApiResponse.ok(userService.checkNicknameDuplication(request.getNickname()));
     }
 
     @Hidden

--- a/src/main/java/com/hongik/dto/user/response/NicknameResponse.java
+++ b/src/main/java/com/hongik/dto/user/response/NicknameResponse.java
@@ -1,0 +1,31 @@
+package com.hongik.dto.user.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class NicknameResponse {
+
+    @Schema(example = "nickname")
+    private String nickname;
+
+    @Schema(example = "false")
+    private boolean isDuplicate;
+
+    @Builder
+    public NicknameResponse(final String nickname, final boolean isDuplicate) {
+        this.nickname = nickname;
+        this.isDuplicate = isDuplicate;
+    }
+
+    public static NicknameResponse of(final String nickname, final boolean isDuplicate) {
+        return NicknameResponse.builder()
+                .nickname(nickname)
+                .isDuplicate(isDuplicate)
+                .build();
+    }
+}

--- a/src/test/java/com/hongik/service/user/UserServiceTest.java
+++ b/src/test/java/com/hongik/service/user/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.hongik.dto.user.request.NicknameRequest;
 import com.hongik.dto.user.request.UserCreateRequest;
 import com.hongik.dto.user.request.UserJoinRequest;
 import com.hongik.dto.user.request.UsernameRequest;
+import com.hongik.dto.user.response.NicknameResponse;
 import com.hongik.dto.user.response.UserResponse;
 import com.hongik.exception.AppException;
 import org.junit.jupiter.api.AfterEach;
@@ -87,7 +88,7 @@ class UserServiceTest {
         userRepository.save(user);
 
         UserCreateRequest request = UserCreateRequest.builder()
-                .username("test@email.com")
+                .username("test2@email.com")
                 .password("password")
                 .nickname(nickname)
                 .department("department")
@@ -99,7 +100,7 @@ class UserServiceTest {
                 .hasMessage("이미 존재하는 닉네임입니다.");
     }
 
-    @DisplayName("닉네임 중복검사를 할 때 이미 닉네임이 존재하면 예외가 발생한다.")
+    @DisplayName("닉네임 중복검사를 할 때 이미 닉네임이 존재하면 true를 반환한다.")
     @Test
     void checkNicknameDuplication() {
         // given
@@ -111,10 +112,13 @@ class UserServiceTest {
                 .nickname(nickname)
                 .build();
 
-        // when // then
-        assertThatThrownBy(() -> userService.checkNicknameDuplication(request.getNickname()))
-                .isInstanceOf(AppException.class)
-                .hasMessage("이미 존재하는 닉네임입니다.");
+        // when
+        NicknameResponse nicknameResponse = userService.checkNicknameDuplication(request.getNickname());
+
+        // then
+        assertThat(nicknameResponse)
+                .extracting("nickname", "isDuplicate")
+                .containsExactlyInAnyOrder(nickname, true);
     }
 
     @DisplayName("회원가입을 진행할 때 중복된 이메일이 존재하면 예외가 발생한다.")


### PR DESCRIPTION
close #54 

## AS-IS
- 닉네임 중복 검사 API 사용 시, 중복일 때 예외가 발생하는 로직에서

## TO-BE
- true, false 반환하는 로직으로 변경
- 회원가입, 테스트 코드 위 로직에 맞게 수정

## KEY-POINT

## SCREENSHOT (Optional)