### PR TITLE
[Refactor] 구글 소셜 로그인 url 변경 및 권한에 따른 true, false 반환

### DIFF
--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -7,6 +7,7 @@ import com.hongik.dto.auth.response.TokenResponse;
 import com.hongik.service.auth.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -25,9 +26,9 @@ public class AuthController {
 //        return authService.getGoogleLoginView();
 //    }
 
-    @Operation(summary = "구글 소셜 로그인", description = "구글, idToken을 넣어주세요.")
-    @PostMapping("/login")
-    public ApiResponse<TokenResponse> selectGoogleLoginInfo(@RequestBody LoginRequest request){
+    @Operation(summary = "구글 소셜 로그인", description = "idToken을 넣어주세요.")
+    @PostMapping("/login-google")
+    public ApiResponse<TokenResponse> selectGoogleLoginInfo(@Valid @RequestBody LoginRequest request){
         return ApiResponse.ok(authService.login(request));
     }
 //    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")

--- a/src/main/java/com/hongik/dto/auth/request/LoginRequest.java
+++ b/src/main/java/com/hongik/dto/auth/request/LoginRequest.java
@@ -1,20 +1,19 @@
 package com.hongik.dto.auth.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @NoArgsConstructor
 @Getter
 public class LoginRequest {
 
-    @Schema(example = "google, apple")
-    private String socialPlatform;
-
+    @Schema(example = "eya2bsd")
+    @NotBlank(message = "idToken은 필수입니다.")
     private String idToken;
 
     @Builder
-    public LoginRequest(final String socialPlatform, final String idToken) {
-        this.socialPlatform = socialPlatform;
+    public LoginRequest(final String idToken) {
         this.idToken = idToken;
     }
 }


### PR DESCRIPTION
close #56 

## AS-IS
- 1) 구글 소셜 로그인 url /api/v1/auth/login 에서
- 2) RequestBody 값 SocialPlatform, idToken 에서
- 3) 로그인시, DB존재 여부로 true, false 반환에서
## TO-BE
- 1) /api/v1/auth/login-google로 변경
- 2) SocialPlatform 제외하고 idToken만 남김
- 3) Role.USER, Role.GUEST로 true, false 반환

## KEY-POINT

## SCREENSHOT (Optional)