### PR TITLE
[Refactor] 닉네임 중복 검사 RequestBody -> RequestParam 으로 수정

### DIFF
--- a/src/main/java/com/hongik/controller/user/UserController.java
+++ b/src/main/java/com/hongik/controller/user/UserController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -38,11 +39,18 @@ public class UserController {
         return ApiResponse.ok(userService.signUp(request));
     }
 
+//    @ApiErrorCodeExamples({INVALID_INPUT_VALUE})
+//    @Operation(summary = "닉네임 중복검사", description = "닉네임 중복검사입니다.")
+//    @GetMapping("/duplicate-nickname")
+//    public ApiResponse<NicknameResponse> duplicateNickname(@Valid @RequestBody NicknameRequest request) {
+//        return ApiResponse.ok(userService.checkNicknameDuplication(request.getNickname()));
+//    }
+
     @ApiErrorCodeExamples({INVALID_INPUT_VALUE})
     @Operation(summary = "닉네임 중복검사", description = "닉네임 중복검사입니다.")
     @GetMapping("/duplicate-nickname")
-    public ApiResponse<NicknameResponse> duplicateNickname(@Valid @RequestBody NicknameRequest request) {
-        return ApiResponse.ok(userService.checkNicknameDuplication(request.getNickname()));
+    public ApiResponse<NicknameResponse> duplicateNickname2(@NotBlank(message = "닉네임은 필수입니다.") @RequestParam String nickname) {
+        return ApiResponse.ok(userService.checkNicknameDuplication(nickname));
     }
 
     @Hidden

--- a/src/test/java/com/hongik/controller/user/UserControllerTest.java
+++ b/src/test/java/com/hongik/controller/user/UserControllerTest.java
@@ -193,62 +193,59 @@ class UserControllerTest {
     @Test
     void duplicateNickname() throws Exception {
         // given
-        NicknameRequest request = NicknameRequest.builder()
-                .nickname("nickname")
-                .build();
 
         // when // then
         mockMvc.perform(
                         get("/api/v1/user/duplicate-nickname").with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
+                                .param("nickname", "nickname")
                 )
                 .andDo(print())
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("닉네임 중복검사할 때 닉네임은 필수값이다.")
-    @Test
-    void duplicateNicknameWithoutNickname() throws Exception {
-        // given
-        NicknameRequest request = NicknameRequest.builder()
-//                .nickname("nickname")
-                .build();
+//    @DisplayName("닉네임 중복검사할 때 닉네임은 필수값이다.")
+//    @Test
+//    void duplicateNicknameWithoutNickname() throws Exception {
+//        // given
+//        NicknameRequest request = NicknameRequest.builder()
+////                .nickname("nickname")
+//                .build();
+//
+//        // when // then
+//        mockMvc.perform(
+//                        get("/api/v1/user/duplicate-nickname").with(csrf())
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(objectMapper.writeValueAsString(request))
+//                )
+//                .andDo(print())
+//                .andExpect(status().isBadRequest())
+//                .andExpect(jsonPath("$.code").value("400"))
+//                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+//                .andExpect(jsonPath("$.message").value("닉네임은 필수입니다."));
+//    }
 
-        // when // then
-        mockMvc.perform(
-                        get("/api/v1/user/duplicate-nickname").with(csrf())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("닉네임은 필수입니다."));
-    }
-
-    @DisplayName("닉네임 중복검사할 때 닉네임은 길이 2~8자, 띄어쓰기와 특수문자는 허용하지 않는다.")
-    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......"})
-    @ParameterizedTest
-    void duplicateNicknameWithInvalidNickname(final String nickname) throws Exception {
-        // given
-        NicknameRequest request = NicknameRequest.builder()
-                .nickname(nickname)
-                .build();
-
-        // when // then
-        mockMvc.perform(
-                        get("/api/v1/user/duplicate-nickname").with(csrf())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
-    }
+//    @DisplayName("닉네임 중복검사할 때 닉네임은 길이 2~8자, 띄어쓰기와 특수문자는 허용하지 않는다.")
+//    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......"})
+//    @ParameterizedTest
+//    void duplicateNicknameWithInvalidNickname(final String nickname) throws Exception {
+//        // given
+//        NicknameRequest request = NicknameRequest.builder()
+//                .nickname(nickname)
+//                .build();
+//
+//        // when // then
+//        mockMvc.perform(
+//                        get("/api/v1/user/duplicate-nickname").with(csrf())
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(objectMapper.writeValueAsString(request))
+//                )
+//                .andDo(print())
+//                .andExpect(status().isBadRequest())
+//                .andExpect(jsonPath("$.code").value("400"))
+//                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+//                .andExpect(jsonPath("$.message").value("띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
+//    }
 
     @DisplayName("이메일 중복검사할 때 이메일은 필수값이다.")
     @Test


### PR DESCRIPTION
close #65 

## AS-IS
- 기존 RequestBody를 이용하여 닉네임 중복 체크를 했던 것을

## TO-BE
- RequestParam으로 수정

## KEY-POINT

## SCREENSHOT (Optional)