### PR TITLE
[Feature] Apple 로그인 Firebase UID 활용하는 로직 추가

### DIFF
--- a/src/main/java/com/hongik/controller/auth/AuthController.java
+++ b/src/main/java/com/hongik/controller/auth/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
     @Operation(summary = "구글 소셜 로그인", description = "idToken을 넣어주세요.")
     @PostMapping("/login-google")
     public ApiResponse<TokenResponse> selectGoogleLoginInfo(@Valid @RequestBody LoginRequest request){
-        return ApiResponse.ok(authService.login(request));
+        return ApiResponse.ok(authService.googleLogin(request));
     }
 //    @Operation(summary = "구글, 애플 소셜 로그인", description = "구글과 애플, id_token을 넣어주세요.")
 //    @PostMapping("/login")

--- a/src/main/java/com/hongik/domain/user/UserRepository.java
+++ b/src/main/java/com/hongik/domain/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.hongik.domain.user;
 
+import io.jsonwebtoken.Claims;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findByPassword(String password);
+
+    Optional<User> findBySub(String sub);
 }

--- a/src/main/java/com/hongik/migration/firebase/FirebaseService.java
+++ b/src/main/java/com/hongik/migration/firebase/FirebaseService.java
@@ -43,6 +43,9 @@
 //
 //        List<User> users = new ArrayList<>();
 //        for (Member member : list) {
+//            if (member.getId() == null || member.getNickname() == null || member.getDepartment() == null) {
+//                continue;
+//            }
 //            User user = User.builder()
 //                    .role(Role.USER)
 //                    .department(member.getDepartment())
@@ -52,6 +55,7 @@
 //                    .build();
 //            users.add(user);
 //        }
+////        System.out.println("list.size() = " + list.size());
 //
 //        userRepository.saveAll(users);
 //        return list;
@@ -72,14 +76,14 @@
 //        }
 //    }
 //
+//    /**
+//     * 11-04 오후 1:50 최신화
+//     */
 //    public List<StudyDay> getAllStudyDays() throws ExecutionException, InterruptedException {
 //        List<User> users = userRepository.findAll();
 //        List<StudySession> sessions = new ArrayList<>();
 //        List<StudyDay> list = new ArrayList<>();
 //        for (User user : users) {
-//            if (user.getPassword() == null || user.getId() < 15L) {
-//                continue;
-//            }
 //
 //            if (user.getNickname().equals("기계")) {
 //                // 1c7kWGDroJPxbUl8lixOg8W6AYy2
@@ -95,6 +99,38 @@
 //                // vYQmuWNMVZVnzbFaAbkG4HAS1s72
 //                continue;
 //            }
+//
+//            if (user.getNickname().equals("깜까미")) {
+//                // DGQhhvkSPvagN1ARmXPr3wEkgmF2
+//                continue;
+//            }
+//
+//            if (user.getNickname().equals("러이")) {
+//                // KU2N5Tx2IYQ9QEpXJbZin5o7hqs1
+//                continue;
+//            }
+//
+//            if (user.getNickname().equals("람드")) {
+//                // LdjPWimIR1PjR0gcRp4C1L0mTGr2
+//                continue;
+//            }
+//
+//            if (user.getNickname().equals("자몽소다")) {
+//                // OkIBFLuGdHR2ytdi3cjEw26F4jc2
+//                continue;
+//            }
+//
+//            if (user.getNickname().equals("무구정광헌")) {
+//                // QqcpsfFbQ9QfXzKI7MUPK0d1HnE2
+//                continue;
+//            }
+//
+//            if (user.getNickname().equals("점수를주호")) {
+//                // VUJ31eGhHvYlxLXXf1vbTPbjg0J2
+//                continue;
+//            }
+//
+//
 //            System.out.println("user.getNickname() = " + user.getNickname());
 //            ApiFuture<QuerySnapshot> future =
 //                    FIRE_STORE.collection(COLLECTION_NAME)

--- a/src/main/java/com/hongik/service/auth/AuthService.java
+++ b/src/main/java/com/hongik/service/auth/AuthService.java
@@ -96,6 +96,8 @@ public class AuthService {
                 }
             }
         } else {
+            // else 문을 탈 때는, UID값이 존재한다는 뜻이고
+            // UID가 존재한다면 findByPassword 를 통해서 계정을 찾을 수 있다.
             user = userRepository.findByPassword(email).get();
             user.updateSub(sub);
             if (user.getRole().equals(Role.USER)) {

--- a/src/main/java/com/hongik/service/auth/AuthService.java
+++ b/src/main/java/com/hongik/service/auth/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
                     .build());
         }
 
-        return TokenResponse.of(jwtUtil.createAccessToken(user, 24 * 60 * 60 * 1000 * 30L), isAlreadyExist);
+        return TokenResponse.of(jwtUtil.createAccessToken(user, 24 * 60 * 60 * 1000 * 365L), isAlreadyExist);
     }
 
     @Transactional
@@ -93,7 +93,7 @@ public class AuthService {
                     .build());
         }
 
-        return TokenResponse.of(jwtUtil.createAccessToken(user, 24 * 60 * 60 * 1000 * 30L), isAlreadyExist);
+        return TokenResponse.of(jwtUtil.createAccessToken(user, 24 * 60 * 60 * 1000 * 365L), isAlreadyExist);
     }
 
     public UserResponse deleteUser(final Long userId) {

--- a/src/main/java/com/hongik/service/auth/AuthService.java
+++ b/src/main/java/com/hongik/service/auth/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenResponse login(LoginRequest request) {
+    public TokenResponse googleLogin(LoginRequest request) {
         User user = null;
         boolean isAlreadyExist = false;
         GoogleInfoResponse googleInfoResponse = googleLoginService.login(request);


### PR DESCRIPTION
close #81 

## AS-IS
- 기존 Firebase UID를 활용하지 않았는데, 

## TO-BE
- 마이그레이션 작업을 위해 UID를 활용하는 로직으로 임시 변경

## KEY-POINT
- 정식 출시 이후 1~2주 정도만 파베를 활용하여 UID를 사용합니다.
- 1~2주 지나면, 기존 로직(sub값으로 회원 찾기)으로 변경합니다.
## SCREENSHOT (Optional)