### PR TITLE
[Feature] 토큰 유효성 검사 API 추가, 최종 회원가입 후 토큰 응답

### DIFF
--- a/src/main/java/com/hongik/config/SecurityConfig.java
+++ b/src/main/java/com/hongik/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/week-field").hasRole("ADMIN")
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/env").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login-google", "/api/v1/auth/login-apple").permitAll()
+                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login-google", "/api/v1/auth/login-apple", "/api/v1/token").permitAll()
                         .anyRequest().hasAnyRole("USER", "ADMIN"))
 //                        .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/hongik/controller/token/TokenController.java
+++ b/src/main/java/com/hongik/controller/token/TokenController.java
@@ -1,0 +1,35 @@
+package com.hongik.controller.token;
+
+import com.hongik.dto.ApiResponse;
+import com.hongik.dto.token.response.TokenValidationResponse;
+import com.hongik.swagger.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collection;
+
+import static com.hongik.exception.ErrorCode.*;
+
+@Tag(name = "Token Controller - 토큰 컨트롤러", description = "토큰 유효성 및 유저의 권한을 응답합니다.")
+@RequestMapping("/api/v1/token")
+@RestController
+public class TokenController {
+
+    @ApiErrorCodeExamples({INVALID_INPUT_VALUE, INVALID_JWT_EXCEPTION, INVALID_EXPIRATION_JWT_EXCEPTION})
+    @Operation(summary = "토큰 유효성 및 유저 권한 응답", description = "토큰이 유효하지 않으면 예외가 발생합니다.")
+    @GetMapping
+    public ApiResponse<TokenValidationResponse> validateToken(Authentication authentication) {
+        String role = "";
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        for (GrantedAuthority authority : authorities) {
+            role = authority.getAuthority().split("_")[1];
+        }
+
+        return ApiResponse.ok(TokenValidationResponse.of(true, role));
+    }
+}

--- a/src/main/java/com/hongik/controller/user/UserController.java
+++ b/src/main/java/com/hongik/controller/user/UserController.java
@@ -5,6 +5,7 @@ import com.hongik.dto.user.request.NicknameRequest;
 import com.hongik.dto.user.request.UserCreateRequest;
 import com.hongik.dto.user.request.UserJoinRequest;
 import com.hongik.dto.user.request.UsernameRequest;
+import com.hongik.dto.user.response.JoinResponse;
 import com.hongik.dto.user.response.NicknameResponse;
 import com.hongik.dto.user.response.UserResponse;
 import com.hongik.service.user.UserService;
@@ -58,8 +59,8 @@ public class UserController {
     @ApiErrorCodeExamples({INVALID_JWT_EXCEPTION, INVALID_INPUT_VALUE, NOT_FOUND_USER, ALREADY_EXIST_NICKNAME})
     @Operation(summary = "닉네임과 학과를 입력하여 회원가입합니다.", description = "닉네임과 학과는 필수이며, 이 과정을 거쳐야 서비스를 이용할 수 있습니다. <br> ROLE.GUEST -> ROLE.USER로 등록합니다.")
     @PostMapping("/join")
-    public ApiResponse<UserResponse> join(@Valid @RequestBody UserJoinRequest request,
-                                             Authentication authentication) {
+    public ApiResponse<JoinResponse> join(@Valid @RequestBody UserJoinRequest request,
+                                          Authentication authentication) {
         Long userId = Long.parseLong(authentication.getName());
         return ApiResponse.ok(userService.join(request, userId));
     }

--- a/src/main/java/com/hongik/dto/token/response/TokenValidationResponse.java
+++ b/src/main/java/com/hongik/dto/token/response/TokenValidationResponse.java
@@ -1,0 +1,31 @@
+package com.hongik.dto.token.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TokenValidationResponse {
+
+    @Schema(example = "true")
+    private boolean isValidToken;
+
+    @Schema(example = "USER")
+    private String Role;
+
+    @Builder
+    public TokenValidationResponse(final boolean isValidToken, final String role) {
+        this.isValidToken = isValidToken;
+        Role = role;
+    }
+
+    public static TokenValidationResponse of(final boolean isValidToken, final String role) {
+        return TokenValidationResponse.builder()
+                .isValidToken(isValidToken)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/hongik/dto/user/response/JoinResponse.java
+++ b/src/main/java/com/hongik/dto/user/response/JoinResponse.java
@@ -1,0 +1,47 @@
+package com.hongik.dto.user.response;
+
+import com.hongik.domain.user.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class JoinResponse {
+
+    @Schema(example = "1")
+    private Long id;
+
+    @Schema(example = "email@email.com")
+    private String username;
+
+    @Schema(example = "닉네임")
+    private String nickname;
+
+    @Schema(example = "디자인학부")
+    private String department;
+
+    @Schema(example = "eyJaiskdfjdieialskd")
+    private String accessToken;
+
+    @Builder
+    public JoinResponse(final Long id, final String username, final String nickname, final String department, final String accessToken) {
+        this.id = id;
+        this.username = username;
+        this.nickname = nickname;
+        this.department = department;
+        this.accessToken = accessToken;
+    }
+
+    public static JoinResponse of(User user, final String accessToken) {
+        return JoinResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .department(user.getDepartment())
+                .accessToken(accessToken)
+                .build();
+    }
+}


### PR DESCRIPTION
close #89 

## AS-IS
- 최종 회원가입을 했을 때, 기존 토큰을 그대로 가져가는 로직에서

## TO-BE
- 최종 회원가입 후, Role 변경에 맞는 새로운 토큰을 발급하는 로직으로 수정했습니다.

## KEY-POINT

## SCREENSHOT (Optional)