### PR TITLE
[Fix] /api/v1/token API(토큰 유효성 검사) Security 권한 설정 오류 수정

### DIFF
--- a/src/main/java/com/hongik/config/SecurityConfig.java
+++ b/src/main/java/com/hongik/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/week-field").hasRole("ADMIN")
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/env").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login-google", "/api/v1/auth/login-apple", "/api/v1/token").permitAll()
+                        .requestMatchers("/api/v1/user/join", "/api/v1/user/duplicate-nickname", "/api/v1/auth/login-google", "/api/v1/auth/login-apple").permitAll()
+                        .requestMatchers("/api/v1/token").authenticated()
                         .anyRequest().hasAnyRole("USER", "ADMIN"))
 //                        .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/hongik/controller/token/TokenController.java
+++ b/src/main/java/com/hongik/controller/token/TokenController.java
@@ -21,7 +21,7 @@ import static com.hongik.exception.ErrorCode.*;
 public class TokenController {
 
     @ApiErrorCodeExamples({INVALID_INPUT_VALUE, INVALID_JWT_EXCEPTION, INVALID_EXPIRATION_JWT_EXCEPTION})
-    @Operation(summary = "토큰 유효성 및 유저 권한 응답", description = "토큰이 유효하지 않으면 예외가 발생합니다.")
+    @Operation(summary = "토큰 유효성 및 유저 권한 응답", description = "토큰이 유효하지 않으면 401예외가 발생합니다.<br> role은 USER, GUEST, ADMIN 값이 옵니다.")
     @GetMapping
     public ApiResponse<TokenValidationResponse> validateToken(Authentication authentication) {
         String role = "";

--- a/src/main/java/com/hongik/dto/token/response/TokenValidationResponse.java
+++ b/src/main/java/com/hongik/dto/token/response/TokenValidationResponse.java
@@ -14,12 +14,12 @@ public class TokenValidationResponse {
     private boolean isValidToken;
 
     @Schema(example = "USER")
-    private String Role;
+    private String role;
 
     @Builder
     public TokenValidationResponse(final boolean isValidToken, final String role) {
         this.isValidToken = isValidToken;
-        Role = role;
+        this.role = role;
     }
 
     public static TokenValidationResponse of(final boolean isValidToken, final String role) {


### PR DESCRIPTION
close #92 

## AS-IS
- permitAll 설정으로 인하여 토큰에 문제가 있을 경우 예외가 발생하지 않았는데

## TO-BE
- authenticated 설정으로 변경하여 토큰에 문제가 발생하면 401 예외가 발생하도록 수정했습니다.

## KEY-POINT
1. 문제 상황: /api/v1/token API 엔드포인트를 permitAll()로 설정했으나, 유효하지 않은 토큰이 전달될 경우 authentication.getAuthorities() 호출 시 NullPointerException이 발생하는 문제를 확인했습니다. 이로 인해 사용자 역할을 확인하는 로직에 예외가 발생했습니다.

2. 해결 과정:
    - 문제 원인 분석: permitAll() 설정으로 인해 인증이 없는 상태에서도 API에 접근할 수 있었고, 유효하지 않은 토큰에 대한 검증 로직이 작동하지 않았습니다.
    - 설정 변경: 엔드포인트 접근 권한을 authenticated()로 수정하여 인증이 완료된 사용자만 접근하도록 설정했습니다.
    - 검증 및 테스트: 설정 변경 후, 만료된 토큰이나 유효하지 않은 토큰이 요청될 경우 Spring Security가 401 Unauthorized 응답을 반환하여 API 로직의 예외 상황이 제거되었음을 확인했습니다.

## SCREENSHOT (Optional)
permitAll 설정이 되어있어서 authentication.getAuthorities() 에서 NullPointerException이 발생합니다.
![image](https://github.com/user-attachments/assets/f02abeb6-e79e-440c-9a89-d0447aaffb9b)

authenticated 설정으로 변경 후 토큰에 문제가 있으면 예외처리가 됩니다.
![image](https://github.com/user-attachments/assets/7a4fb38e-cd78-4aec-bf23-5fa2d5ee2f23)

