### PR TITLE
[Fix] 애플로그인 회원탈퇴 후 재가입 불가능 오류 수정

### DIFF
--- a/src/main/java/com/hongik/service/auth/AuthService.java
+++ b/src/main/java/com/hongik/service/auth/AuthService.java
@@ -106,10 +106,20 @@ public class AuthService {
             // else 문을 탈 때는, UID값이 존재한다는 뜻이고
             // UID가 존재한다면 findByPassword 를 통해서 계정을 찾을 수 있다.
             log.info("UID값 존재 = {}", email);
-            user = userRepository.findByPassword(email).get();
-            user.updateSub(sub);
-            if (user.getRole().equals(Role.USER)) {
-                isAlreadyExist = true;
+            if (userRepository.findByPassword(email).isEmpty()) {
+                log.info("findByPassword로 유저가 없음, 회원탈퇴 후 재가입 회원");
+                user = userRepository.save(User.builder()
+                        .username(appleInfoResponse.get("email", String.class))
+                        .sub(sub)
+                        .role(Role.GUEST)
+                        .build());
+            } else {
+                log.info("파이어베이스에 존재하는 유저가 로그인한 상황");
+                user = userRepository.findByPassword(email).get();
+                user.updateSub(sub);
+                if (user.getRole().equals(Role.USER)) {
+                    isAlreadyExist = true;
+                }
             }
         }
 


### PR DESCRIPTION
close #98 

## AS-IS
- 파베에 존재하는 유저가 탈퇴 후 재가입 시 에러 발생했는데, 

## TO-BE
- 로직을 추가하여 에러 해결

## KEY-POINT

## SCREENSHOT (Optional)