### PR TITLE
[Refactor] 닉네임 검증 규칙 문자 + 숫자 -> 문자로 변경

### DIFF
--- a/src/main/java/com/hongik/controller/user/UserController.java
+++ b/src/main/java/com/hongik/controller/user/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
     @ApiErrorCodeExamples({INVALID_INPUT_VALUE})
     @Operation(summary = "닉네임 중복검사", description = "닉네임 중복검사입니다.")
     @GetMapping("/duplicate-nickname")
-    public ApiResponse<NicknameResponse> duplicateNickname(@Pattern(regexp = "^[A-Za-z0-9가-힣]{2,8}$", message = "띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다.") @NotBlank(message = "닉네임은 필수입니다.") @RequestParam String nickname) {
+    public ApiResponse<NicknameResponse> duplicateNickname(@Pattern(regexp = "^[A-Za-z가-힣]{2,8}$", message = "띄어쓰기, 숫자, 특수문자는 불가능하고, 2~8자까지 허용합니다.") @NotBlank(message = "닉네임은 필수입니다.") @RequestParam String nickname) {
         return ApiResponse.ok(userService.checkNicknameDuplication(nickname));
     }
 

--- a/src/main/java/com/hongik/dto/user/request/UserCreateRequest.java
+++ b/src/main/java/com/hongik/dto/user/request/UserCreateRequest.java
@@ -24,7 +24,7 @@ public class UserCreateRequest {
 
     @Schema(example = "닉네임")
     @NotBlank(message = "닉네임은 필수입니다.")
-    @Pattern(regexp = "^[A-Za-z0-9가-힣]{2,8}$", message = "띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다.")
+    @Pattern(regexp = "^[A-Za-z가-힣]{2,8}$", message = "띄어쓰기, 숫자, 특수문자는 불가능하고, 2~8자까지 허용합니다.")
     private String nickname;
 
     @Schema(example = "디자인학부")

--- a/src/test/java/com/hongik/controller/user/UserControllerTest.java
+++ b/src/test/java/com/hongik/controller/user/UserControllerTest.java
@@ -165,7 +165,7 @@ class UserControllerTest {
     }
 
     @DisplayName("회원가입할 때 닉네임은 길이 2~8자, 띄어쓰기와 특수문자는 허용하지 않는다.")
-    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......"})
+    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......", "안녕2"})
     @ParameterizedTest
     void createUserWithInvalidNickname(final String nickname) throws Exception {
         // given
@@ -186,7 +186,7 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
+                .andExpect(jsonPath("$.message").value("띄어쓰기, 숫자, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
     }
 
     @DisplayName("닉네임 중복검사")
@@ -222,7 +222,7 @@ class UserControllerTest {
     }
 
     @DisplayName("닉네임 중복검사할 때 닉네임은 길이 2~8자, 띄어쓰기와 특수문자는 허용하지 않는다.")
-    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......"})
+    @CsvSource({"닉 네 임", "닉네임!!", "닉네임8자넘었습니다", "닉", "!!!!", "......", "안녕1"})
     @ParameterizedTest
     void duplicateNicknameWithInvalidNickname(final String nickname) throws Exception {
         // given
@@ -237,7 +237,7 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("띄어쓰기, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
+                .andExpect(jsonPath("$.message").value("띄어쓰기, 숫자, 특수문자는 불가능하고, 2~8자까지 허용합니다."));
     }
 
     @DisplayName("이메일 중복검사할 때 이메일은 필수값이다.")


### PR DESCRIPTION
close #107 

## AS-IS
- 기존 닉네임 문자 + 숫자 허용에서

## TO-BE
- 문자만 허용하도록 수정했습니다.

## KEY-POINT

## SCREENSHOT (Optional)