### PR TITLE
[Refactor] (캘린더) 모든 날짜 공부 횟수 조회 쿼리 Object[] -> DTO로 리팩토링

### DIFF
--- a/src/main/java/com/hongik/domain/study/StudySessionRepository.java
+++ b/src/main/java/com/hongik/domain/study/StudySessionRepository.java
@@ -1,5 +1,6 @@
 package com.hongik.domain.study;
 
+import com.hongik.dto.study.response.StudyCountLocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -71,11 +72,15 @@ public interface StudySessionRepository extends JpaRepository<StudySession, Long
                                         @Param("year") int year,
                                         @Param("month") int month);
 
+    /**
+     * 20xx년 전체 공부 횟수를 조회한다.
+     * 캘린더에 공부 횟수로 색칠한다.
+     */
     @Query(value = "SELECT DATE(s.start_time) AS date, COUNT(*) AS studyCount " +
             "FROM study_session s " +
             "WHERE s.user_id = :userId " +
             "GROUP BY DATE(s.start_time)", nativeQuery = true)
-    List<Object[]> getStudyCountByAll(@Param("userId") Long userId);
+    List<StudyCountLocalDate> getStudyCountByAll(@Param("userId") Long userId);
 
     @Query(value = "SELECT DATE(s.start_time) AS date, COUNT(*) AS studyCount " +
             "FROM study_session s " +

--- a/src/main/java/com/hongik/dto/study/response/StudyCountLocalDate.java
+++ b/src/main/java/com/hongik/dto/study/response/StudyCountLocalDate.java
@@ -1,0 +1,10 @@
+package com.hongik.dto.study.response;
+
+import java.time.LocalDate;
+
+public interface StudyCountLocalDate {
+
+    LocalDate getDate();
+    Long getStudyCount();
+
+}

--- a/src/main/java/com/hongik/service/study/StudySessionService.java
+++ b/src/main/java/com/hongik/service/study/StudySessionService.java
@@ -84,15 +84,20 @@ public class StudySessionService {
                 .collect(toList());
     }
 
+    /**
+     * 20xx년 전체 공부 횟수를 조회한다.
+     * 캘린더에 공부 횟수로 색칠한다.
+     */
     public List<StudyCountLocalDateResponse> getStudyCountAll(final Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_USER, ErrorCode.NOT_FOUND_USER.getMessage()));
 
-        List<Object[]> results = studySessionRepository.getStudyCountByAll(userId);
+        List<StudyCountLocalDate> results = studySessionRepository.getStudyCountByAll(userId);
+
         return results.stream()
                 .map(result -> StudyCountLocalDateResponse.of(
-                        ((java.sql.Date) result[0]).toLocalDate(),
-                        ((Number) result[1]).longValue()
+                        result.getDate(),
+                        result.getStudyCount()
                 ))
                 .collect(toList());
     }

--- a/src/test/java/com/hongik/domain/study/StudySessionRepositoryTest.java
+++ b/src/test/java/com/hongik/domain/study/StudySessionRepositoryTest.java
@@ -3,6 +3,7 @@ package com.hongik.domain.study;
 import com.hongik.domain.user.Role;
 import com.hongik.domain.user.User;
 import com.hongik.domain.user.UserRepository;
+import com.hongik.dto.study.response.StudyCountLocalDate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -168,11 +169,11 @@ class StudySessionRepositoryTest {
         studySessionRepository.saveAll(List.of(studySession1, studySession2, studySession3, studySession4));
 
         // when
-        List<Object[]> result = studySessionRepository.getStudyCountByAll(user.getId());
+        List<StudyCountLocalDate> result = studySessionRepository.getStudyCountByAll(user.getId());
 
         // then
         assertThat(result).hasSize(3)
-                .extracting(row -> ((java.sql.Date) row[0]).toLocalDate(), row -> (Long) row[1])
+                .extracting("date", "studyCount")
                 .containsExactlyInAnyOrder(
                         tuple(LocalDate.of(2024, 9, 19), 2L),
                         tuple(LocalDate.of(2024, 9, 20), 1L),


### PR DESCRIPTION
close #110 

## AS-IS
- /api/v1/study/count-all API - 기존 쿼리 반환값이 Object[] 에서

## TO-BE
- Dto로 리팩토링을 진행했습니다.

## KEY-POINT
### 리팩토링 전
- 코드 가독성 문제: 기존 Object[] 배열을 사용하면 각 인덱스(Object[0], Object[1] 등)로 접근해야 하므로 어떤 데이터가 어떤 인덱스에 위치하는지 명확하지 않아 코드의 이해도가 떨어졌습니다.
- 타입 안전성 부족: 배열 내부 요소에 접근할 때 타입 변환이 필요했고, 잘못된 타입으로 캐스팅하여 에러가 발생할 수 있습니다.
- 유지보수 어려움: 데이터 구조가 변경될 경우 각 인덱스의 위치를 수정해야 하고 실수를 유발할 수 있습니다.
- 테스트 작성 복잡: List<Object[]>로 반환을 받기 때문에 extracting 하는 과정이 매우 복잡합니다. 
ex) assertThat(result).hasSize(3)
              .extracting(row -> ((java.sql.Date) row[0]).toLocalDate(), row -> (Long) row[1])
              .containsExactlyInAnyOrder(
                      tuple(LocalDate.of(2024, 9, 19), 2L),
                      tuple(LocalDate.of(2024, 9, 20), 1L),
                      tuple(LocalDate.of(2024, 8, 20), 1L)
              );

### 리팩토링 후
- 가독성 향상: 명확한 필드명을 가진 Dto를 사용하여 데이터를 직관적으로 접근할 수 있습니다.
- 유지보수 용이: 새로운 필드를 추가하거나 변경할 때 Dto 클래스만 수정하면 됩니다.
- 타입 안전성: Object[] 방식에서 발생할 수 있는 타입 캐스팅 오류를 방지할 수 있습니다.
- 재사용성: 중복 코드 감소합니다.
- 테스트 작성 용이: 테스트 코드를 작성할 때 직관적으로 접근하고 테스트할 수 있습니다.

## SCREENSHOT (Optional)
### Service 코드
![image](https://github.com/user-attachments/assets/799957bd-d3d1-4dfd-a7bd-19f38c499886)

### Repository 코드
![image](https://github.com/user-attachments/assets/00861a37-35df-4aba-8e0c-ede6e04885cc)
기존 코드는 date, studyCount 순서대로 index가 0, 1 값이다.
개선 후, index 값을 신경쓰지 않아도 된다.

### Repository Test 코드
![image](https://github.com/user-attachments/assets/964a2375-a62e-4e58-bbae-74ad2630dd59)
기존 코드는 test 코드 작성 시, Object[] 에 대한 index와 타입 캐스팅이 필요했다.
