### PR TITLE
[Refactor] (홈 화면 주간 캘린더) 1주일 공부 횟수 조회 쿼리 Object[] -> DTO로 리팩토링

### DIFF
--- a/src/main/java/com/hongik/domain/study/StudySessionRepository.java
+++ b/src/main/java/com/hongik/domain/study/StudySessionRepository.java
@@ -1,5 +1,6 @@
 package com.hongik.domain.study;
 
+import com.hongik.dto.study.response.StudyCount;
 import com.hongik.dto.study.response.StudyCountLocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -87,7 +88,7 @@ public interface StudySessionRepository extends JpaRepository<StudySession, Long
             "WHERE s.user_id = :userId " +
             "and DATE(s.start_time) in :dates " +
             "GROUP BY DATE(s.start_time)", nativeQuery = true)
-    List<Object[]> getStudyCountByWeek(@Param("userId") Long userId, List<LocalDate> dates);
+    List<StudyCount> getStudyCountByWeek(@Param("userId") Long userId, List<LocalDate> dates);
 
     /**
      * 2024년 10월 01일 기준

--- a/src/main/java/com/hongik/domain/study/StudySessionRepository.java
+++ b/src/main/java/com/hongik/domain/study/StudySessionRepository.java
@@ -83,6 +83,12 @@ public interface StudySessionRepository extends JpaRepository<StudySession, Long
             "GROUP BY DATE(s.start_time)", nativeQuery = true)
     List<StudyCountLocalDate> getStudyCountByAll(@Param("userId") Long userId);
 
+    /**
+     * 20xx년 x월 x일에 대한 월요일~일요일 공부 횟수를 조회한다.
+     * 홈 화면 일주일 캘린더에 공부 횟수로 색칠한다.
+     * 반환값은 LocalDate, Long
+     * @return StudyCount(LocalDate, Long)
+     */
     @Query(value = "SELECT DATE(s.start_time) AS date, COUNT(*) AS studyCount " +
             "FROM study_session s " +
             "WHERE s.user_id = :userId " +

--- a/src/main/java/com/hongik/dto/study/response/StudyCount.java
+++ b/src/main/java/com/hongik/dto/study/response/StudyCount.java
@@ -1,0 +1,11 @@
+package com.hongik.dto.study.response;
+
+import java.time.LocalDate;
+
+public interface StudyCount {
+
+    LocalDate getDate();
+    Long getStudyCount();
+
+
+}

--- a/src/main/java/com/hongik/service/study/StudySessionService.java
+++ b/src/main/java/com/hongik/service/study/StudySessionService.java
@@ -116,29 +116,22 @@ public class StudySessionService {
         }
 
         // 일주일을 Map에 담는다.
-        Map<LocalDate, Long> week = new LinkedHashMap<>();
+        Map<String, Long> week = new LinkedHashMap<>();
         for (LocalDate date : dates) {
-            week.put(date, 0L);
+            String formattedDate = date.format(DateTimeFormatter.ofPattern("M/dd"));
+            week.put(formattedDate, 0L);
         }
 
         // Controller에서 받은 한 주의 날짜의 공부 횟수를 조회한다. -> 공부 횟수가 존재하지 않으면 값이 나오지 않는다.
-        List<Object[]> results = studySessionRepository.getStudyCountByWeek(userId, dates);
+        List<StudyCount> results = studySessionRepository.getStudyCountByWeek(userId, dates);
 
         // 위 쿼리를 이용하여 Map에 존재하면 쿼리 조회 결과(공부 횟수)로 덮어씌운다.
-        for (Object[] result : results) {
-            LocalDate localDate = ((Date) result[0]).toLocalDate();
-            if (week.containsKey(localDate)) {
-                week.put(localDate, (Long) result[1]);
-            }
+        for (StudyCount result : results) {
+            String formattedDate = result.getDate().format(DateTimeFormatter.ofPattern("M/dd"));
+            week.put(formattedDate, result.getStudyCount());
         }
 
-        Map<String, Long> weeks = new LinkedHashMap<>();
-        for (LocalDate localDate : week.keySet()) {
-            String date = localDate.format(DateTimeFormatter.ofPattern("M/dd"));
-            weeks.put(date, week.get(localDate));
-        }
-
-        return weeks.entrySet().stream()
+        return week.entrySet().stream()
                 .map(entry -> StudyCountResponse.of(entry.getKey(), entry.getValue()))
                 .collect(toList());
     }

--- a/src/main/java/com/hongik/service/study/StudySessionService.java
+++ b/src/main/java/com/hongik/service/study/StudySessionService.java
@@ -102,6 +102,12 @@ public class StudySessionService {
                 .collect(toList());
     }
 
+    /**
+     * 20xx년 x월 x일에 대한 월요일~일요일 공부 횟수를 조회한다.
+     * 홈 화면 일주일 캘린더에 공부 횟수로 색칠한다.
+     * 반환값은 String(M/dd), Long 형식이다. ex) 10/1, 3 ... 10/2, 2 ... 10/7 5
+     * @return StudyCountResponse(String, Long)
+     */
     public List<StudyCountResponse> getStudyCountOfWeek(LocalDate today, final Long userId) {
         // 이번 주의 시작일 (월요일)
         LocalDate startOfWeek = today.with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));


### PR DESCRIPTION
close #112 

## AS-IS
- /api/v1/study/week API - 일주일 공부 횟수 조회 쿼리 반환값 Object[] 에서

## TO-BE
- Dto로 리팩토링 진행했습니다.
- Service에서 Map 초기화 및 덮어쓰기 과정을 제거하고 쿼리 결과를 Dto에 매핑함으로써 코드 가독성 및 유지보수성이 향상되었습니다.

## KEY-POINT
### 리팩토링 전
- 비효율적인 쿼리 호출: 기존에는 월요일~일요일 값(LocalDate, Long)을 Map에 초기화하고 쿼리 결과로 덮어쓰는 불필요한 방식입니다.
- Map<LocalDate, Long>과 Map<String, Long> 두 개를 사용하여 'M/dd'로 포매팅한 결과를 출력하였습니다.
- 코드 가독성 문제: 기존 Object[] 배열을 사용하면 각 인덱스(Object[0], Object[1] 등)로 접근해야 하므로 어떤 데이터가 어떤 인덱스에 위치하는지 명확하지 않아 코드의 이해도가 떨어졌습니다.
- 타입 안전성 부족: 배열 내부 요소에 접근할 때 타입 변환이 필요했고, 잘못된 타입으로 캐스팅하여 에러가 발생할 수 있습니다.
- 유지보수 어려움: 데이터 구조가 변경될 경우 각 인덱스의 위치를 수정해야 하고 실수를 유발할 수 있습니다.

### 리팩토링 후
- Map 초기화 및 덮어쓰는 방식을 개선하였습니다.
- Map<String, Long> 하나로 변경하여 불필요한 메모리 사용을 줄였습니다.
- 가독성 향상: 명확한 필드명을 가진 Dto를 사용하여 데이터를 직관적으로 접근할 수 있습니다.
- 타입 안전성: Object[] 방식에서 발생할 수 있는 타입 캐스팅 오류를 방지할 수 있습니다.
- 유지보수 용이: 새로운 필드를 추가하거나 변경할 때 Dto 클래스만 수정하면 됩니다.

## SCREENSHOT (Optional)
### Repository 코드
![image](https://github.com/user-attachments/assets/59e8e7de-a5f4-433e-8f59-92c744d8e7cc)

### Service 코드
![image](https://github.com/user-attachments/assets/6fadf399-f0e5-41fb-b230-0e7f10f442cd)
불필요한 Map 초기화 및 덮어쓰기 개선

![image](https://github.com/user-attachments/assets/fea6aa3b-ab85-4f9a-90e4-57fb6e587bdc)
불필요한 타입 캐스팅 개선
