### PR TITLE
[Fix] 프로필을 수정할 때, 학과만 수정할 경우 닉네임 중복 예외 발생 버그 수정

### DIFF
--- a/src/main/java/com/hongik/service/user/UserService.java
+++ b/src/main/java/com/hongik/service/user/UserService.java
@@ -85,12 +85,24 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_USER, ErrorCode.NOT_FOUND_USER.getMessage()));
 
-        if (checkNicknameDuplication(request.getNickname()).isDuplicate()) {
-            throw new AppException(ErrorCode.ALREADY_EXIST_NICKNAME, ErrorCode.ALREADY_EXIST_NICKNAME.getMessage());
+        // 학과만 변경하는 경우는 닉네임 중복 검사를 하지 않는다.
+        if (isNicknameChanged(request.getNickname(), user.getNickname())) {
+            // 본인 닉네임과 변경하는 닉네임이 다른 경우는 닉네임 중복검사를 한다.
+            if (checkNicknameDuplication(request.getNickname()).isDuplicate()) {
+                throw new AppException(ErrorCode.ALREADY_EXIST_NICKNAME, ErrorCode.ALREADY_EXIST_NICKNAME.getMessage());
+            }
         }
 
         user.updateProfile(request.getNickname(), request.getDepartment());
 
         return UserResponse.of(user);
+    }
+
+    /**
+     * 닉네임 변경은 새로운 닉네임과 기존 닉네임이 다르기 때문에
+     * 변경할 때는 True가 반환된다.
+     */
+    private boolean isNicknameChanged(final String newNickname, final String oldNickname) {
+        return !newNickname.equals(oldNickname);
     }
 }


### PR DESCRIPTION
close #130 

## AS-IS
- 변경하는 닉네임과 본인 닉네임이 같은 경우에도 닉네임 중복 예외가 발생했던 문제를

## TO-BE
- 닉네임 중복 검사를 수행하지 않도록 로직을 변경했습니다.

## KEY-POINT

## SCREENSHOT (Optional)