### PR TITLE
Feature/#138 record details

### DIFF
--- a/src/main/java/com/hongik/controller/study/StudySessionController.java
+++ b/src/main/java/com/hongik/controller/study/StudySessionController.java
@@ -36,12 +36,15 @@ public class StudySessionController {
     }
 
     @ApiErrorCodeExamples({INVALID_JWT_EXCEPTION, INVALID_INPUT_VALUE, REGISTRATION_INCOMPLETE, NOT_FOUND_USER})
-    @Operation(summary = "(기록 화면 캘린더 공부 횟수와 함께 표시) 연간, 월간, 투데이, 학기 공부 시간 조회", description = "서버 기준 현재 시간을 기준으로 날짜를 정합니다. <br> Minute을 제공합니다.")
+    @Operation(summary = "(기록 화면 캘린더 공부 횟수와 함께 표시) 연간, 월간, 투데이 공부 시간 조회", description = "Param값이 없으면 서버 기준 현재 시간을 기준으로 날짜를 정합니다. <br> Minute을 제공합니다.")
     @GetMapping("/duration")
-    public ApiResponse<StudyDurationResponse> getStudyDuration(Authentication authentication) {
+    public ApiResponse<StudyDurationResponse> getStudyDuration(Authentication authentication,
+                                                               @RequestParam(required = false) LocalDate date) {
         Long userId = Long.parseLong(authentication.getName());
-        LocalDate now = LocalDate.now();
-        return ApiResponse.ok(studySessionService.getStudyDuration(now, userId));
+        if (date == null) {
+            date = LocalDate.now();
+        }
+        return ApiResponse.ok(studySessionService.getStudyDuration(date, userId));
     }
 
     @Hidden
@@ -88,4 +91,5 @@ public class StudySessionController {
 
         return ApiResponse.ok(studySessionService.getStudyDurationRanking(yearWeek));
     }
+
 }

--- a/src/main/java/com/hongik/dto/study/response/StudyDurationResponse.java
+++ b/src/main/java/com/hongik/dto/study/response/StudyDurationResponse.java
@@ -1,6 +1,5 @@
 package com.hongik.dto.study.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,23 +21,17 @@ public class StudyDurationResponse {
 
     private Long dayMinutes;
 
-    private Long semesterHours;
-
-    private Long semesterMinutes;
-
     @Builder
-    public StudyDurationResponse(final Long yearHours, final Long yearMinutes, final Long monthHours, final Long monthMinutes, final Long dayHours, final Long dayMinutes, final Long semesterHours, final Long semesterMinutes) {
+    public StudyDurationResponse(final Long yearHours, final Long yearMinutes, final Long monthHours, final Long monthMinutes, final Long dayHours, final Long dayMinutes) {
         this.yearHours = yearHours;
         this.yearMinutes = yearMinutes;
         this.monthHours = monthHours;
         this.monthMinutes = monthMinutes;
         this.dayHours = dayHours;
         this.dayMinutes = dayMinutes;
-        this.semesterHours = semesterHours;
-        this.semesterMinutes = semesterMinutes;
     }
 
-    public static StudyDurationResponse of(final Long yearHours, final Long yearMinutes, final Long monthHours, final Long monthMinutes, final Long dayHours, final Long dayMinutes, final Long semesterHours, final Long semesterMinutes) {
+    public static StudyDurationResponse of(final Long yearHours, final Long yearMinutes, final Long monthHours, final Long monthMinutes, final Long dayHours, final Long dayMinutes) {
         return StudyDurationResponse.builder()
                 .yearHours(yearHours)
                 .yearMinutes(yearMinutes)
@@ -46,8 +39,6 @@ public class StudyDurationResponse {
                 .monthMinutes(monthMinutes)
                 .dayHours(dayHours)
                 .dayMinutes(dayMinutes)
-                .semesterHours(semesterHours)
-                .semesterMinutes(semesterMinutes)
                 .build();
     }
 }

--- a/src/main/java/com/hongik/service/study/StudySessionService.java
+++ b/src/main/java/com/hongik/service/study/StudySessionService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
@@ -43,15 +42,13 @@ public class StudySessionService {
         return StudySessionResponse.of(savedStudySession);
     }
 
-    public StudyDurationResponse getStudyDuration(final LocalDate now, final Long userId) {
+    public StudyDurationResponse getStudyDuration(final LocalDate date, final Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_USER, ErrorCode.NOT_FOUND_USER.getMessage()));
 
-        final int year = now.getYear();
-        final int month = now.getMonthValue();
-        final int day = now.getDayOfMonth();
-
-        String currentSemester = getCurrentSemester(month);
+        final int year = date.getYear();
+        final int month = date.getMonthValue();
+        final int day = date.getDayOfMonth();
 
         Long studyDurationWithYear = studySessionRepository.getStudyDurationForYearAsSeconds(userId, year);
         Long yearHours = studyDurationWithYear / 3600;
@@ -65,11 +62,7 @@ public class StudySessionService {
         Long dayHours = studyDurationWithDay / 3600;
         Long dayMinutes = studyDurationWithDay % 3600 / 60;
 
-        Long studyDurationWithSemester = studySessionRepository.getStudyDurationForSemesterAsSeconds(userId, year, currentSemester);
-        Long semesterHours = studyDurationWithSemester / 3600;
-        Long semesterMinutes = studyDurationWithSemester % 3600 / 60;
-
-        return StudyDurationResponse.of(yearHours, yearMinutes, monthHours, monthMinutes, dayHours, dayMinutes, semesterHours, semesterMinutes);
+        return StudyDurationResponse.of(yearHours, yearMinutes, monthHours, monthMinutes, dayHours, dayMinutes);
     }
 
     public List<StudyCountLocalDateResponse> getStudyCount(final int year, final int month, final Long userId) {

--- a/src/test/java/com/hongik/service/study/StudySessionServiceTest.java
+++ b/src/test/java/com/hongik/service/study/StudySessionServiceTest.java
@@ -60,12 +60,11 @@ class StudySessionServiceTest {
                 .containsExactlyInAnyOrder(now, now.plusMinutes(5));
     }
     
-    @DisplayName("서버 시간 기준으로 유저의 날짜(Year, Month, Day, Semester)에 대한 공부 시간 조회")
+    @DisplayName("Param 값이 없을 때, 서버 시간 기준으로 유저의 날짜(Year, Month, Day)에 대한 공부 시간 조회")
     @Test
     void getStudyDuration() {
         // given
         LocalDate now = LocalDate.of(2024, 9, 20);
-        // 9월은 2학기다.
         User user = createUser("username", "password", "nickname", "디자인학부");
         userRepository.save(user);
 
@@ -73,7 +72,6 @@ class StudySessionServiceTest {
         2024년 - 3시간 3분
         2024년 9월 - 3시간 3분
         2024년 9월 19일 - 2시간 2분, 2024년 9월 20일 - 1시간 1분
-        학기(second) - 3시간 3분
          */
         LocalDateTime startTime1 = LocalDateTime.of(2024, 9, 19, 10, 10);
         LocalDateTime endTime1 = LocalDateTime.of(2024, 9, 19, 11, 11);
@@ -106,10 +104,52 @@ class StudySessionServiceTest {
                 .containsExactly(
                         1L, 1L
                 );
+    }
+
+    @DisplayName("Param 값이 있을 때, 날짜(Year, Month, Day)에 대한 공부 시간 조회")
+    @Test
+    void getStudyDurationWithLocalDate() {
+        // given
+        LocalDate date = LocalDate.of(2024, 8, 20);
+        User user = createUser("username", "password", "nickname", "디자인학부");
+        userRepository.save(user);
+
+        /*
+        2024년 - 3시간 3분
+        2024년 8월 - 2시간 2분
+        2024년 8월 19일 - 1시간 1분
+        2024년 8월 20일 - 1시간 1분
+         */
+        LocalDateTime startTime1 = LocalDateTime.of(2024, 9, 19, 10, 10);
+        LocalDateTime endTime1 = LocalDateTime.of(2024, 9, 19, 11, 11);
+        LocalDateTime startTime2 = LocalDateTime.of(2024, 8, 19, 20, 10);
+        LocalDateTime endTime2 = LocalDateTime.of(2024, 8, 19, 21, 11);
+        LocalDateTime startTime3 = LocalDateTime.of(2024, 8, 20, 20, 10);
+        LocalDateTime endTime3 = LocalDateTime.of(2024, 8, 20, 21, 11);
+        StudySession studySession1 = createStudySession(user, startTime1, endTime1);
+        StudySession studySession2 = createStudySession(user, startTime2, endTime2);
+        StudySession studySession3 = createStudySession(user, startTime3, endTime3);
+        studySessionRepository.saveAll(List.of(studySession1, studySession2, studySession3));
+
+        // when
+        StudyDurationResponse studyDurationResponse = studySessionService.getStudyDuration(date, user.getId());
+
+        // then
+        assertThat(studyDurationResponse).isNotNull();
         assertThat(studyDurationResponse)
-                .extracting("semesterHours", "semesterMinutes")
+                .extracting("yearHours", "yearMinutes")
                 .containsExactly(
                         3L, 3L
+                );
+        assertThat(studyDurationResponse)
+                .extracting("monthHours", "monthMinutes")
+                .containsExactly(
+                        2L, 2L
+                );
+        assertThat(studyDurationResponse)
+                .extracting("dayHours", "dayMinutes")
+                .containsExactly(
+                        1L, 1L
                 );
     }
 


### PR DESCRIPTION
close #138 

## AS-IS
- 현재 날짜에 맞는 공부 시간만 조회할 수 있었는데,

## TO-BE
- 원하는 날짜의 공부 시간을 조회할 수 있는 기능을 추가하였습니다.

## KEY-POINT
- 학기 공부 시간 데이터는 제거되었습니다.
- RequestParam을 활용하여 현재 날짜 또는 원하는 날짜의 공부 시간을 조회할 수 있습니다.

## SCREENSHOT (Optional)
![image](https://github.com/user-attachments/assets/58c525bd-e49a-4d60-a831-d5c1814f7722)
