### PR TITLE
fix: 도커에서 지원하지 않는 17-jdk-slim 태그 eclipse-temurin:17-jdk-jammy로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /app
 ARG JAR_FILE=build/libs/*.jar
 ARG PROFILES


### PR DESCRIPTION
## AS-IS
- 도커에서 17-jdk-slim 태그 지원 중단
## TO-BE
- eclipse-temurin:17-jdk-jammy 태그로 변경
## KEY-POINT

## SCREENSHOT (Optional)