### PR TITLE
fix: 친구, 알림 목록 조회 시 값이 없으면 null 값 반환되게 수정

### DIFF
--- a/src/main/java/com/hongik/service/friend/FriendService.java
+++ b/src/main/java/com/hongik/service/friend/FriendService.java
@@ -36,7 +36,7 @@ public class FriendService {
 	private final NotificationService notificationService;
 
 	@Transactional
-	public FriendCreateResponse createFriend(Long userId, FriendCreateRequest request) { //TODO: 친구 조회 방식  다시 생각해보기
+	public FriendCreateResponse createFriend(Long userId, FriendCreateRequest request) {
 		User findSender = userRepository.findById(userId).orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND_USER,
 				ErrorCode.NOT_FOUND_USER.getMessage()));
 		User findReceiver = userRepository.findById(request.getReceiverId())
@@ -121,7 +121,7 @@ public class FriendService {
 		List<User> searchFriends = userRepository.findAllByNicknameContainsAndIdNot(nickname, userId);
 
 		if (searchFriends.isEmpty()) {
-			throw new AppException(ErrorCode.NOT_FOUND_USER, ErrorCode.NOT_FOUND_USER.getMessage());
+			return List.of();
 		}
 
 		return searchFriends.stream()
@@ -169,7 +169,7 @@ public class FriendService {
 		List<Friend> findFriends = friendRepository.findFriend(userId);
 
 		if (findFriends.isEmpty()) {
-			throw new AppException(ErrorCode.NOT_FOUND_FRIEND, ErrorCode.NOT_FOUND_FRIEND.getMessage());
+			return List.of();
 		}
 
 		LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/hongik/service/notification/NotificationService.java
+++ b/src/main/java/com/hongik/service/notification/NotificationService.java
@@ -61,7 +61,7 @@ public class NotificationService {
 		List<Notification> findNotifications = notificationRepository.findByReceiverIdAndIsReadOrderByCreatedAtDesc(userId, false);
 
 		if (findNotifications.isEmpty()) {
-			throw new AppException(ErrorCode.NOT_FOUND_NOTIFICATION, ErrorCode.NOT_FOUND_NOTIFICATION.getMessage());
+			return List.of();
 		}
 
 		return findNotifications.stream()


### PR DESCRIPTION
## AS-IS
- 친구, 알림 목록 조회 시 값이 없으면 404 에러 발생
## TO-BE
- 친구, 알림 목록 조회 시 값이 없으면 data가 null 값으로 반화되게 수정
## KEY-POINT

## SCREENSHOT (Optional)